### PR TITLE
feat: get feedback also when no response was chosen (MAPCO-5804)

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -56,7 +56,10 @@
     "groupId": "KAFKA_CONSUMER_GROUP_ID"
   },
   "kafkaTopics": {
-    "input": "KAFKA_INPUT_TOPIC"
+    "input": {
+      "__name": "KAFKA_INPUT_TOPIC",
+      "__format": "json"
+    }
   },
   "elastic": {
     "node": "ELASTIC_URL",

--- a/config/default.json
+++ b/config/default.json
@@ -38,7 +38,7 @@
     "groupId": "123"
   },
   "kafkaTopics": {
-    "input": "topic"
+    "input": ["topic"]
   },
   "elastic": {
     "node": "http://elasticsearch:9200",

--- a/config/test.json
+++ b/config/test.json
@@ -3,6 +3,6 @@
     "groupId": "123-test"
   },
   "kafkaTopics": {
-    "input": "topic1-test,topic2-test"
+    "input": ["topic1-test", "topic2-test"]
   }
 }

--- a/config/test.json
+++ b/config/test.json
@@ -1,1 +1,8 @@
-{}
+{
+  "kafkaConsumer": {
+    "groupId": "123-test"
+  },
+  "kafkaTopics": {
+    "input": "topic1-test,topic2-test"
+  }
+}

--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -29,9 +29,7 @@ paths:
                 chosenResultId:
                   oneOf:
                     - type: number
-                    - type: string
-                      enum:
-                        - ''
+                      nullable: true
                 responseTime:
                   type: string
                   format: date-time

--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -27,7 +27,11 @@ paths:
                 requestId:
                   type: string
                 chosenResultId:
-                  type: number
+                  oneOf:
+                    - type: number
+                    - type: string
+                      enum:
+                        - ''
                 responseTime:
                   type: string
                   format: date-time
@@ -99,7 +103,6 @@ components:
     geocodingResponse:
       type: object
       required:
-        - userId
         - apiKey
         - site
         - response

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -38,7 +38,7 @@ export interface FeedbackResponse {
 }
 
 export interface GeocodingResponse {
-  userId: string | null;
+  userId?: string;
   apiKey: string;
   site: string;
   response: QueryResult;

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -7,7 +7,7 @@ export interface IConfig {
 }
 
 export interface EnrichResponse {
-  user: {
+  user?: {
     [key: string]: string | UserDataServiceResponse;
     name: string;
   };
@@ -16,13 +16,13 @@ export interface EnrichResponse {
     language: string;
   };
   result: {
-    rank: number;
-    score: number;
+    rank: number | null;
+    score?: number;
     source?: string;
     layer?: string;
-    name: string;
+    name?: string;
     location?: Feature<Point>;
-    region: string;
+    region?: string;
   };
   system: string;
   site: string;
@@ -32,13 +32,13 @@ export interface EnrichResponse {
 
 export interface FeedbackResponse {
   requestId: string;
-  chosenResultId: number;
+  chosenResultId: number | string;
   responseTime: Date; // from FeedbackApi
   geocodingResponse: GeocodingResponse;
 }
 
 export interface GeocodingResponse {
-  userId: string;
+  userId: string | null;
   apiKey: string;
   site: string;
   response: QueryResult;

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -32,7 +32,7 @@ export interface EnrichResponse {
 
 export interface FeedbackResponse {
   requestId: string;
-  chosenResultId: number | string;
+  chosenResultId: number | null;
   responseTime: Date; // from FeedbackApi
   geocodingResponse: GeocodingResponse;
 }

--- a/src/process/models/processManager.ts
+++ b/src/process/models/processManager.ts
@@ -52,13 +52,9 @@ export class ProcessManager {
   }
 
   public async enrichData(feedbackResponse: FeedbackResponse, enrichedResponse: EnrichResponse): Promise<EnrichResponse> {
-    let score = 0;
     const chosenResult: number = feedbackResponse.chosenResultId as number;
     const selectedResponse = feedbackResponse.geocodingResponse.response.features[chosenResult];
 
-    if (selectedResponse.properties._score) {
-      score = selectedResponse.properties._score;
-    }
     const { endpoint, queryParams, headers } = this.appConfig.userDataService;
     const fetchedUserData = await fetchUserDataService(endpoint, feedbackResponse.geocodingResponse.userId as string, queryParams, headers);
 
@@ -68,7 +64,7 @@ export class ProcessManager {
     };
     enrichedResponse.result = {
       rank: chosenResult,
-      score,
+      score: selectedResponse.properties?._score ?? 0,
       source: selectedResponse.properties.matches[0].source,
       layer: selectedResponse.properties.matches[0].layer,
       name: selectedResponse.properties.names.default,

--- a/src/process/models/processManager.ts
+++ b/src/process/models/processManager.ts
@@ -34,7 +34,7 @@ export class ProcessManager {
       duration: new Date(feedbackResponse.responseTime) - new Date(feedbackResponse.geocodingResponse.respondedAt),
       timestamp: new Date(),
     };
-    if (feedbackResponse.chosenResultId === '') {
+    if (feedbackResponse.chosenResultId === null) {
       return enrichedResponse;
     }
     return this.enrichData(feedbackResponse, enrichedResponse);
@@ -64,6 +64,7 @@ export class ProcessManager {
     };
     enrichedResponse.result = {
       rank: chosenResult,
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       score: selectedResponse.properties?._score ?? 0,
       source: selectedResponse.properties.matches[0].source,
       layer: selectedResponse.properties.matches[0].layer,

--- a/src/streamerBuilder.ts
+++ b/src/streamerBuilder.ts
@@ -9,7 +9,7 @@ import { FeedbackResponse, IConfig, KafkaOptions } from './common/interfaces';
 import { ProcessManager } from './process/models/processManager';
 
 interface KafkaTopics {
-  input: string;
+  input: string[];
 }
 
 const elasticIndex = 'elastic.properties.index';
@@ -53,7 +53,8 @@ export class StreamerBuilder {
     const { input: inputTopic } = this.config.get<KafkaTopics>('kafkaTopics');
 
     await this.consumer.connect();
-    await this.consumer.subscribe({ topics: inputTopic.split(',') });
+    await this.consumer.subscribe({ topics: inputTopic });
+    this.logger.info(`Kafka consumer subscribed successfully to ${inputTopic.toString()}`);
 
     await this.consumer.run({
       eachMessage: async ({ message }) => {

--- a/tests/integration/process/process.spec.ts
+++ b/tests/integration/process/process.spec.ts
@@ -14,7 +14,7 @@ import { ProcessRequestSender } from './helpers/requestSender';
 import { mockApiKey } from './utils';
 
 let currentKafkaTopics = {
-  input: 'topic1-test',
+  input: ['topic1-test'],
 };
 
 jest.mock('config', () => {
@@ -187,7 +187,7 @@ describe('process', function () {
     it('should return 200 status code and the resource when given multiple kafka topics', async function () {
       const userId = 'avi@mapcolonies.net';
       currentKafkaTopics = {
-        input: 'topic1-test,topic2-test',
+        input: ['topic1-test', 'topic2-test'],
       };
       const userDataServiceScope = nock(config.get<IApplication>('application').userDataService.endpoint, {
         reqheaders: {
@@ -313,7 +313,7 @@ describe('process', function () {
 
     it('should return 200 status code when getting missing data - meaning user did not choose a response', async function () {
       currentKafkaTopics = {
-        input: 'topic1-test,topic2-test',
+        input: ['topic1-test', 'topic2-test'],
       };
       const input: FeedbackResponse = {
         requestId: 'req-id',

--- a/tests/integration/process/process.spec.ts
+++ b/tests/integration/process/process.spec.ts
@@ -317,7 +317,7 @@ describe('process', function () {
       };
       const input: FeedbackResponse = {
         requestId: 'req-id',
-        chosenResultId: '',
+        chosenResultId: null,
         responseTime: new Date(10000 + 500),
         geocodingResponse: {
           apiKey: mockApiKey,


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✔                                                                       |

Now also when a user does not press on any response from geocoding, after a certain amount of time we will get feedback that no result was chosen. Then we enrich the following feedback and add it to ElasticSearch.